### PR TITLE
Fix transmission tree none

### DIFF
--- a/R/output_treeGenerator.r
+++ b/R/output_treeGenerator.r
@@ -238,7 +238,7 @@ merge_state_tables <- function(nosoiInf) {
 }
 
 ## Utility functions to get entries in the table, returning NA if does not exist.
-is.error <- function(x) inherits(x, "try-error")
+# is.error <- function(x) inherits(x, "try-error")
 safeGet <- function(dt, i, name) {
   res <- dt[i, ][[name]]
   if (is.null(res)) return(NA);

--- a/tests/testthat/testDualContinuous.R
+++ b/tests/testthat/testDualContinuous.R
@@ -90,6 +90,9 @@ test_that("Both hosts move", {
                           diff.pTrans.B=FALSE,
                           prefix.host.B="V")
 
+  ## Output
+  expect_output(print(test.nosoiA), "a dual host with a continuous structure")
+
   full.results.nosoi <- rbindlist(list(test.nosoiA$host.info.A$table.hosts,test.nosoiA$host.info.B$table.hosts))
   full.results.nosoi.state <- rbindlist(list(test.nosoiA$host.info.A$table.state,test.nosoiA$host.info.B$table.state))
 

--- a/tests/testthat/testDualDiscrete.R
+++ b/tests/testthat/testDualDiscrete.R
@@ -73,6 +73,9 @@ test_that("Movement is coherent with single introduction, constant pMove, diff p
                           diff.pTrans.B=FALSE,
                           prefix.host.B="V")
 
+  ## Output
+  expect_output(print(test.nosoiA), "a dual host with a discrete structure")
+
   full.results.nosoi <- rbindlist(list(test.nosoiA$host.info.A$table.hosts,test.nosoiA$host.info.B$table.hosts))
   full.results.nosoi.state <- rbindlist(list(test.nosoiA$host.info.A$table.state,test.nosoiA$host.info.B$table.state))
 

--- a/tests/testthat/testDualNone.R
+++ b/tests/testthat/testDualNone.R
@@ -49,6 +49,8 @@ test_that("Transmission is coherent with single introduction (host A) same for b
                           timeDep.pTrans.B=FALSE,
                           prefix.host.B="V")
 
+  ## Output
+  expect_output(print(test.nosoiA), "a dual host with no structure")
 
   full.results.nosoi <- rbindlist(list(getHostData(test.nosoiA, "table.host", "A"),getHostData(test.nosoiA, "table.host", "B")))
 

--- a/tests/testthat/testSingleContinuous.R
+++ b/tests/testthat/testSingleContinuous.R
@@ -184,6 +184,9 @@ test_that("Diffusion in continuous space", {
                           pExit=p_Exit_fct,
                           param.pExit=NA)
 
+  ## Output
+  expect_output(print(test.nosoiA), "a single host with a continuous structure")
+
   expect_equal(nrow(getHostData(test.nosoiA, "table.hosts")),648)
   expect_equal(nrow(subset(getHostData(test.nosoiA, "table.state"), hosts.ID == "H-1")),3)
 

--- a/tests/testthat/testSingleDiscrete.R
+++ b/tests/testthat/testSingleDiscrete.R
@@ -164,6 +164,9 @@ test_that("Movement is coherent with single introduction, constant pMove", {
                           param.pExit=NA
   )
 
+  ## Output
+  expect_output(print(test.nosoiA), "a single host with a discrete structure")
+
   #Structure
   g <- graph.data.frame(getHostData(test.nosoiA, "table.hosts")[,c(1,2)],directed=F)
   expect_equal(transitivity(g, type="global"), 0)

--- a/tests/testthat/testSingleNone.R
+++ b/tests/testthat/testSingleNone.R
@@ -32,6 +32,9 @@ test_that("Transmission is coherent with single introduction, constant pExit and
   dynNew <- getDynamic(test.nosoiA)
   expect_equal(dynOld, dynNew)
 
+  ## Output
+  expect_output(print(test.nosoiA), "a single host with no structure")
+
 })
 
 


### PR DESCRIPTION
Fixing issue #12:
- Make `getTransmissionTree` work for unstructured populations
- Add tests with unstructured populations.