### PR TITLE
Fix CRAN issues

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^README.md$
 ^CRAN-RELEASE$
 ^\.github$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ docs/reference/SingleNone.html
 docs/reference/updateHostCount.html
 docs/reference/updateTableState.html
 docs/reference/writeInfected.html
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nosoi
 Type: Package
 Title: A Forward Agent-Based Transmission Chain Simulator
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(person("Sebastian", "Lequime", email = "sebastian.lequime@gmail.com",
                   role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3140-0651")),
                   person("Paul", "Bastide", email = "paul.bastide@umontpellier.fr",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,9 @@ Authors@R: c(person("Sebastian", "Lequime", email = "sebastian.lequime@gmail.com
                   person("Philippe", "Lemey", email = "philippe.lemey@kuleuven.be",
                   role = "aut", comment = c(ORCID = "0000-0003-2826-5353")),
                   person("Guy", "Baele", email = "guy.baele@kuleuven.be",
-                  role = "aut", comment = c(ORCID = "0000-0002-1915-7732")))
+                  role = "aut", comment = c(ORCID = "0000-0002-1915-7732")),
+                  person("Thijs", "Janzen", email = "t.janzen@rug.nl",
+                  role = "ctb", comment = c(ORCID = "0000-0002-4162-1140")))
 Description: The aim of 'nosoi' (pronounced no.si) is to provide a flexible agent-based stochastic transmission chain/epidemic simulator (Lequime et al. Methods in Ecology and Evolution 11:1002-1007). It is named after the daimones of plague, sickness and disease that escaped Pandora's jar in the Greek mythology. 'nosoi' is able to take into account the influence of multiple variable on the transmission process (e.g. dual-host systems (such as arboviruses), within-host viral dynamics, transportation, population structure), alone or taken together, to create complex but relatively intuitive epidemiological simulations.
 URL: https://github.com/slequime/nosoi
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ URL: https://github.com/slequime/nosoi
 Language: en-US
 License: GPL-3
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3
 biocViews:
 Depends: 
     data.table (>= 1.12.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# nosoi 1.1.2
+* Minor fixes and corrections (documentation, vignettes)
+
 # nosoi 1.1.1
 * `tidyverse` no longer in 'Suggests'.
 * Updating website

--- a/R/nosoiSim.R
+++ b/R/nosoiSim.R
@@ -114,7 +114,7 @@ nosoiSim <- function(type="single", popStructure="none", ...){
 #' @description
 #' Creates a \code{nosoiSim} object.
 #'
-#' @param pres.time current time of the simulation
+#' @param total.time total time of the simulation
 #' @param type population structure (one of "single or "dual)
 #' @param pop.A an object of class \code{nosoiSimOne} for population A
 #' @param pop.B an object of class \code{nosoiSimOne} for population B
@@ -139,7 +139,6 @@ nosoiSimConstructor <- function(total.time,
   class(res) <- "nosoiSim"
 
   return(res)
-
 }
 
 ##

--- a/R/nosoi_sanityChecks-Messages.R
+++ b/R/nosoi_sanityChecks-Messages.R
@@ -15,7 +15,7 @@
 CoreSanityChecks <- function(length.sim, max.infected, init.individuals) {
   if (is.na(length.sim) || length.sim <= 1) stop("You must specify a length (in time units) for your simulation (bigger than 1).")
   if (is.na(max.infected) || max.infected <= 1) stop("You must specify a maximum number of infected hosts (bigger than 1).")
-  if (is.na(init.individuals) || init.individuals < 1 || !init.individuals%%1==0) stop("The transmission chain should be started by 1 or more (integer) individuals.")
+  if (is.na(init.individuals) || init.individuals < 1 || !init.individuals %%1 == 0) stop("The transmission chain should be started by 1 or more (integer) individuals.")
 }
 
 #' @title Checks if a function is properly formatted
@@ -29,7 +29,6 @@ CoreSanityChecks <- function(length.sim, max.infected, init.individuals) {
 #' @param timeDep is the function differential according to absolute time? (TRUE/FALSE)
 #' @param diff is the function differential according to state/env.variable? (TRUE/FALSE)
 #' @param hostCount is the function differential according to host count? (TRUE/FALSE)
-#' @param structure is the function to be used in a structured population? (TRUE/FALSE)
 #' @param continuous is the function to be used in a continuous space? (TRUE/FALSE)
 #' @param stateNames name of the states (vector) in case of discrete structure.
 #'
@@ -49,15 +48,15 @@ FunctionSanityChecks <- function(pFunc, name, param.pFunc, timeDep, diff, hostCo
       || (diff == TRUE && timeDep == FALSE && hostCount == FALSE && length(formalArgs(pFunc)) > 2)
       || (diff == TRUE && timeDep == FALSE && hostCount == TRUE && length(formalArgs(pFunc)) > 3)
       || (diff == FALSE && timeDep == TRUE && length(formalArgs(pFunc)) > 2)
-      || (diff == TRUE && timeDep==TRUE && hostCount == FALSE && length(formalArgs(pFunc)) > 3)
-      || (diff == TRUE && timeDep==TRUE && hostCount == TRUE && length(formalArgs(pFunc)) > 4)) {
+      || (diff == TRUE && timeDep == TRUE && hostCount == FALSE && length(formalArgs(pFunc)) > 3)
+      || (diff == TRUE && timeDep == TRUE && hostCount == TRUE && length(formalArgs(pFunc)) > 4)) {
     if (!is.list(param.pFunc) && is.na(param.pFunc)) {
       stop("There is a probleme with your function ", name, ": you should provide a parameter list named param.", name, ".")
     }
 
     if (is.list(param.pFunc)) {
       pFunc.param <- formalArgs(pFunc)[-1]
-      if(! all(names(param.pFunc) %in% pFunc.param)) stop("Parameter name in param.", name, " should match the name used in ", name, ".")
+      if(!all(names(param.pFunc) %in% pFunc.param)) stop("Parameter name in param.", name, " should match the name used in ", name, ".")
     }
   }
 
@@ -111,7 +110,7 @@ MatrixSanityChecks <- function(structure.matrix, init.structure, none.at.start=N
 ##
 
 RasterSanityChecks <- function(structure.raster, init.structure, none.at.start=NULL) {
-  if(!class(structure.raster) == "RasterLayer") stop("structure.raster must be a raster (class RasterLayer).")
+  if(!inherits(structure.raster, "RasterLayer")) stop("structure.raster must be a raster (class RasterLayer).")
 
   if(is.null(none.at.start)){
     start.env <- raster::extract(structure.raster,cbind(init.structure[1],init.structure[2]))

--- a/R/nosoi_tablesManagment.R
+++ b/R/nosoi_tablesManagment.R
@@ -9,7 +9,6 @@
 #' @param hosts.ID unique ID for the new host
 #' @param infected.by unique ID of host that transmits to the new one
 #' @param infected.in state in which the host was infected
-#' @param current.in state in which the host currently is
 #' @param time.is time in the simulation, when the infection takes place
 #' @param ParamHost list of individual based parameters.
 #' @param current.environmental.value current environmental value
@@ -22,10 +21,14 @@
 #' @keywords internal
 
 newLine <- function(hosts.ID,
-                    infected.by, infected.in,
+                    infected.by,
+                    infected.in,
                     time.is,
-                    ParamHost, current.environmental.value = NULL, current.cell.number.raster = NULL,
-                    current.count.A = integer(0), current.count.B = integer(0)) {
+                    ParamHost,
+                    current.environmental.value = NULL,
+                    current.cell.number.raster = NULL,
+                    current.count.A = integer(0),
+                    current.count.B = integer(0)) {
 
   if (length(infected.in) == 1) {
     if (is.na(infected.in)) infected.in <- NULL

--- a/R/nosoi_utilityFunctions.R
+++ b/R/nosoi_utilityFunctions.R
@@ -15,8 +15,8 @@
 #'
 #' @return list of parsed quantities:
 #' \itemize{
-#'  \item{"vect"}{Vectorized version of the function.}
-#'  \item{"vectArgs"}{Vector of arguments for the vectorized function.}
+#'  \item "vect" Vectorized version of the function.
+#'  \item "vectArgs" Vector of arguments for the vectorized function.
 #' }
 #'
 #' @keywords internal

--- a/R/output_treeGenerator.r
+++ b/R/output_treeGenerator.r
@@ -50,9 +50,9 @@
 #' )
 #'
 #' ## Make sure all needed packages are here
-#' if (requireNamespace("ape", quietly = TRUE)
-#'     || requireNamespace("tidytree", quietly = TRUE)
-#'     || requireNamespace("treeio", quietly = TRUE)) {
+#' if (requireNamespace("ape", quietly = TRUE) &&
+#'     requireNamespace("tidytree", quietly = TRUE) &&
+#'     requireNamespace("treeio", quietly = TRUE)) {
 #'   library(ape)
 #'   library(tidytree)
 #'   library(treeio)
@@ -84,7 +84,9 @@
 #' @export getTransmissionTree
 
 getTransmissionTree <- function(nosoiInf) {
-  if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", quietly = TRUE) || !requireNamespace("treeio", quietly = TRUE)) {
+  if (!(requireNamespace("ape", quietly = TRUE) &&
+        requireNamespace("tidytree", quietly = TRUE) &&
+        requireNamespace("treeio", quietly = TRUE))) {
     stop("Packages 'ape', 'tidytree' and 'treeio' are needed for transmission tree generation.",
          call. = FALSE)
   }

--- a/R/single-none.R
+++ b/R/single-none.R
@@ -61,7 +61,6 @@
 #'test.nosoi
 #'}
 #' @export singleNone
-
 singleNone <- function(length.sim,
                        max.infected,
                        init.individuals,

--- a/man/FunctionSanityChecks.Rd
+++ b/man/FunctionSanityChecks.Rd
@@ -31,8 +31,6 @@ FunctionSanityChecks(
 \item{continuous}{is the function to be used in a continuous space? (TRUE/FALSE)}
 
 \item{stateNames}{name of the states (vector) in case of discrete structure.}
-
-\item{structure}{is the function to be used in a structured population? (TRUE/FALSE)}
 }
 \description{
 Checks if the function is properly formatted given the user's input and nosoi's requirements.

--- a/man/getTransmissionTree.Rd
+++ b/man/getTransmissionTree.Rd
@@ -58,9 +58,9 @@ test.nosoi <- nosoiSim(type="single", popStructure="discrete",
 )
 
 ## Make sure all needed packages are here
-if (requireNamespace("ape", quietly = TRUE)
-    || requireNamespace("tidytree", quietly = TRUE)
-    || requireNamespace("treeio", quietly = TRUE)) {
+if (requireNamespace("ape", quietly = TRUE) &&
+    requireNamespace("tidytree", quietly = TRUE) &&
+    requireNamespace("treeio", quietly = TRUE)) {
   library(ape)
   library(tidytree)
   library(treeio)

--- a/man/keep.tip.treedata.Rd
+++ b/man/keep.tip.treedata.Rd
@@ -4,7 +4,7 @@
 \alias{keep.tip.treedata}
 \title{Keep tips}
 \usage{
-keep.tip.treedata(tree, tip)
+\method{keep.tip}{treedata}(tree, tip)
 }
 \description{
 Keep the tips in the list. See \code{\link[ape:drop.tip]{keep.tip}}

--- a/man/keep.tip.treedata.Rd
+++ b/man/keep.tip.treedata.Rd
@@ -4,7 +4,7 @@
 \alias{keep.tip.treedata}
 \title{Keep tips}
 \usage{
-\method{keep.tip}{treedata}(tree, tip)
+keep.tip.treedata(tree, tip)
 }
 \description{
 Keep the tips in the list. See \code{\link[ape:drop.tip]{keep.tip}}

--- a/man/newLine.Rd
+++ b/man/newLine.Rd
@@ -34,8 +34,6 @@ newLine(
 \item{current.count.A}{current count of host A}
 
 \item{current.count.B}{current count of host B}
-
-\item{current.in}{state in which the host currently is}
 }
 \value{
 a list with the new line to add.

--- a/man/nosoiSimConstructor.Rd
+++ b/man/nosoiSimConstructor.Rd
@@ -12,13 +12,13 @@ nosoiSimConstructor(
 )
 }
 \arguments{
+\item{total.time}{total time of the simulation}
+
 \item{type}{population structure (one of "single or "dual)}
 
 \item{pop.A}{an object of class \code{nosoiSimOne} for population A}
 
 \item{pop.B}{an object of class \code{nosoiSimOne} for population B}
-
-\item{pres.time}{current time of the simulation}
 }
 \value{
 An object of class \code{nosoiSim}

--- a/man/parseFunction.Rd
+++ b/man/parseFunction.Rd
@@ -35,8 +35,8 @@ parseFunction(
 \value{
 list of parsed quantities:
 \itemize{
- \item{"vect"}{Vectorized version of the function.}
- \item{"vectArgs"}{Vector of arguments for the vectorized function.}
+ \item "vect" Vectorized version of the function.
+ \item "vectArgs" Vector of arguments for the vectorized function.
 }
 }
 \description{

--- a/man/sampleTransmissionTree.Rd
+++ b/man/sampleTransmissionTree.Rd
@@ -69,9 +69,9 @@ test.nosoi <- nosoiSim(type="single", popStructure="discrete",
 )
 
 ## Make sure all needed packages are here
-if (requireNamespace("ape", quietly = TRUE)
-    || requireNamespace("tidytree", quietly = TRUE)
-    || requireNamespace("treeio", quietly = TRUE)) {
+if (requireNamespace("ape", quietly = TRUE) &&
+    requireNamespace("tidytree", quietly = TRUE) &&
+    requireNamespace("treeio", quietly = TRUE)) {
   library(ape)
   library(tidytree)
   library(treeio)

--- a/man/sampleTransmissionTreeFromExiting.Rd
+++ b/man/sampleTransmissionTreeFromExiting.Rd
@@ -63,9 +63,9 @@ test.nosoi <- nosoiSim(type="single", popStructure="discrete",
 )
 
 ## Make sure all needed packages are here
-if (requireNamespace("ape", quietly = TRUE)
-    || requireNamespace("tidytree", quietly = TRUE)
-    || requireNamespace("treeio", quietly = TRUE)) {
+if (requireNamespace("ape", quietly = TRUE) &&
+    requireNamespace("tidytree", quietly = TRUE) &&
+    requireNamespace("treeio", quietly = TRUE)) {
   library(ape)
   library(tidytree)
   library(treeio)

--- a/nosoi.Rproj
+++ b/nosoi.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/testSingleNone.R
+++ b/tests/testthat/testSingleNone.R
@@ -28,9 +28,11 @@ test_that("Transmission is coherent with single introduction, constant pExit and
   expect_equal(clusters(g, "weak")$no, 1)
   expect_equal(diameter(g, directed=F, weights=NA), 12)
 
-  dynOld <- getDynamicOld(test.nosoiA)
-  dynNew <- getDynamic(test.nosoiA)
-  expect_equal(dynOld, dynNew)
+  if (requireNamespace("dplyr")) {
+    dynOld <- getDynamicOld(test.nosoiA)
+    dynNew <- getDynamic(test.nosoiA)
+    expect_equal(dynOld, dynNew)
+  }
 
   ## Output
   expect_output(print(test.nosoiA), "a single host with no structure")

--- a/vignettes/continuous.Rmd
+++ b/vignettes/continuous.Rmd
@@ -54,7 +54,8 @@ test.raster <- focal(focal(test.raster, w=matrix(1, 5, 5), mean), w=matrix(1, 5,
 
 test.raster_df <- as.data.frame(test.raster, xy = TRUE) 
 
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("viridis", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) && 
+      requireNamespace("viridis", quietly = TRUE))) {
   message("Packages 'ggplot2' and 'viridis' are needed for plotting this figure.")
 } else {
   library(ggplot2)
@@ -189,7 +190,8 @@ move.test2$type = "Not attracted by raster"
 
 move.test.all = rbindlist(list(move.test,move.test2))
 
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("viridis", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) &&
+      requireNamespace("viridis", quietly = TRUE))) {
   message("Packages 'ggplot2' and 'viridis' are needed for plotting this figure.")
 } else {
   ggplot() +

--- a/vignettes/discrete.Rmd
+++ b/vignettes/discrete.Rmd
@@ -7,8 +7,8 @@ vignette: >
   %\VignetteIndexEntry{Spread of a pathogen in a discrete structured population}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-  %\VignetteDepends{ggplot2}
   %\VignetteDepends{dplyr}
+  %\VignetteDepends{ggplot2}
   %\VignetteDepends{igraph}
   %\VignetteDepends{viridis}
   %\VignetteDepends{ggnetwork}
@@ -43,7 +43,7 @@ matrix(c(0, 0.2, 0.4,
        dimnames = list(c("A", "B", "C"), c("A", "B", "C")))
 ```
 
-It can graphically be represented as follow:
+It can graphically be represented as follows:
 
 ```{r setupMatrix, echo=FALSE, message=FALSE, warning=FALSE}
 if (!(requireNamespace("ggplot2", quietly = TRUE) &&
@@ -60,8 +60,8 @@ if (!(requireNamespace("ggplot2", quietly = TRUE) &&
   transition.matrix <- matrix(c(0, 0.2, 0.4, 0.5, 0, 0.6, 0.5, 0.8, 0),
                               nrow = 3,
                               ncol = 3,
-                              dimnames=list(c("A", "B", "C"),
-                                            c("A", "B", "C")))
+                              dimnames = list(c("A", "B", "C"),
+                                              c("A", "B", "C")))
   
   # melting the matrix go get from -> to in one line with probability
   # melted.transition.matrix <- reshape2::melt(transition.matrix, varnames = c("from","to"), value.name="prob", as.is = TRUE)

--- a/vignettes/discrete.Rmd
+++ b/vignettes/discrete.Rmd
@@ -4,7 +4,7 @@ author: "Sebastian Lequime"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Spread of a pathogen in a discrete structured population}
+%\VignetteIndexEntry{Spread of a pathogen in a discrete structured population}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
   %\VignetteDepends{dplyr}
@@ -12,12 +12,12 @@ vignette: >
   %\VignetteDepends{igraph}
   %\VignetteDepends{viridis}
   %\VignetteDepends{ggnetwork}
----
-
-```{r setup, include=FALSE}
+  ---
+  
+  ```{r setup, include=FALSE}
 knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>"
+collapse = TRUE,
+comment = "#>"
 )
 ```
 
@@ -64,7 +64,6 @@ if (!(requireNamespace("ggplot2", quietly = TRUE) &&
                                               c("A", "B", "C")))
   
   # melting the matrix go get from -> to in one line with probability
-  # melted.transition.matrix <- reshape2::melt(transition.matrix, varnames = c("from","to"), value.name="prob", as.is = TRUE)
   melted.transition.matrix <- as.data.frame.table(transition.matrix,
                                                   stringsAsFactors = FALSE)
   colnames(melted.transition.matrix) <- c("from", "to", "prob")
@@ -77,35 +76,49 @@ if (!(requireNamespace("ggplot2", quietly = TRUE) &&
   
   graph.Matrix2 = igraph::layout_in_circle(graph.Matrix)
   
-  #using ggnetwork to provide the layout
-  graph.matrix.network <- ggnetwork::ggnetwork(graph.Matrix,
-                                               layout = graph.Matrix2,
-                                               arrow.gap = 0.18) 
   
-  graph.matrix.network2 <- subset(graph.matrix.network,
-                                  !is.na(graph.matrix.network$prob))
-  
-  #plotting the network
-  ggplot(graph.matrix.network, aes(x = x, y = y, xend = xend, yend = yend)) +
-    geom_edges(color = "grey70",
-               arrow = arrow(length = unit(1, "lines"),
-                             type = "closed"),
-               curvature = 0.2) +
-    geom_nodes(aes(color = name) , size = 30) +
-    geom_nodetext(aes(label = name),
-                  color = "white",
-                  fontface = "bold",
-                  size = 15) +
-    scale_color_viridis(guide = FALSE, discrete = TRUE) +
-    theme_blank() +
-    ylim(-0.5, 1.2) +
-    xlim(-0.5, 1.2) +
-    geom_text(data = graph.matrix.network2,
-              aes(x = (x + xend) / 2,
-                  y = (y + yend) / 2,
-                  label = prob, 
-                  color = name),
-              size = 6)
+  if (utils::packageVersion("ggnetwork") > "0.5.12") {
+    # unfortunately, the update to igraph 2.0.0 has broken the connection
+    # between ggnetwork and igraph, see: 
+    # https://github.com/briatte/ggnetwork/issues/74
+    
+    #using ggnetwork to provide the layout
+    graph.matrix.network <- ggnetwork::ggnetwork(x = graph.Matrix,
+                                                 layout = graph.Matrix2,
+                                                 arrow.gap = 0.18)
+    
+    graph.matrix.network2 <- subset(graph.matrix.network,
+                                    !is.na(graph.matrix.network$prob))
+    
+    #plotting the network
+    ggplot(graph.Matrix, aes(x = x, y = y, xend = xend, yend = yend)) +
+      geom_edges(color = "grey70",
+                 arrow = arrow(length = unit(1, "lines"),
+                               type = "closed"),
+                 curvature = 0.2) +
+      geom_nodes(aes(color = name) , size = 30) +
+      geom_nodetext(aes(label = name),
+                    color = "white",
+                    fontface = "bold",
+                    size = 15) +
+      scale_color_viridis(guide = FALSE, discrete = TRUE) +
+      theme_blank() +
+      ylim(-0.5, 1.2) +
+      xlim(-0.5, 1.2) +
+      geom_text(data = graph.matrix.network2,
+                aes(x = (x + xend) / 2,
+                    y = (y + yend) / 2,
+                    label = prob, 
+                    color = name),
+                size = 6)
+  } else {
+    plot(graph.Matrix,
+         edge.label = melted.transition.matrix$prob,
+         vertex.color = "white",
+         edge.curved = seq(-0.5, 0.5, length = 1 + ecount(graph.Matrix)), 
+         arrow.mode = 3,
+         edge.arrow.size = 0.3)
+  }
 }
 ```
 
@@ -341,9 +354,9 @@ We choose `pTrans` in the form of a threshold function: before a certain amount 
 
 ```{r pTrans1, eval=FALSE}
 p_Trans_fct <- function(t, p_max, t_incub){
-    if(t < t_incub){p=0}
-    if(t >= t_incub){p=p_max}
-    return(p)
+  if(t < t_incub){p=0}
+  if(t >= t_incub){p=p_max}
+  return(p)
 }
 ```
 
@@ -377,17 +390,23 @@ if (!(requireNamespace("ggplot2", quietly = TRUE) &&
   t_incub_fct <- function(x){rnorm(x,mean = 7,sd=1)}
   p_max_fct <- function(x){rbeta(x,shape1 = 5,shape2=2)}
   
-  data = data.frame(t_incub=t_incub_fct(200),p_max=p_max_fct(200),host=paste0("H-",1:200))
+  data = data.frame(t_incub = t_incub_fct(200),
+                    p_max = p_max_fct(200),
+                    host = paste0("H-", 1:200))
   
   t=c(0:12)
   data3=NULL
   for(t in 0:15){
-    data2 = data %>% group_by(host) %>% mutate(proba=p_Trans_fct(t=t,p_max=p_max, t_incub=t_incub))
+    data2 = data %>% group_by(host) %>% 
+      mutate(proba = p_Trans_fct(t = t, p_max = p_max, t_incub = t_incub))
     data2$t = t
     data3 = rbind(data3, data2)
   }
   
-  ggplot(data=data3, aes(x=t, y=proba,group=host)) + geom_line(color="grey60") + theme_minimal() + labs(x="Time since infection (t)",y="pTrans")
+  ggplot(data = data3, aes(x = t, y = proba, group = host)) + 
+    geom_line(color = "grey60") +
+    theme_minimal() +
+    labs(x = "Time since infection (t)", y = "pTrans")
 }
 ```
 
@@ -648,7 +667,7 @@ n_contact_fct.B = function(t){sample(c(0,1,2),1,prob=c(0.6,0.3,0.1))}
 p_Trans_fct.B <- function(t, max.time){
   dnorm(t, mean=max.time, sd=2)*5
 }
- 
+
 max.time_fct <- function(x){rnorm(x,mean = 5,sd=1)}
 
 param_pTrans.B = list(max.time=max.time_fct)

--- a/vignettes/discrete.Rmd
+++ b/vignettes/discrete.Rmd
@@ -46,7 +46,10 @@ matrix(c(0, 0.2, 0.4,
 It can graphically be represented as follow:
 
 ```{r setupMatrix, echo=FALSE, message=FALSE,warning=FALSE}
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("viridis", quietly = TRUE) || !requireNamespace("igraph", quietly = TRUE) || !requireNamespace("ggnetwork", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) &&
+      requireNamespace("viridis", quietly = TRUE) &&
+      requireNamespace("igraph", quietly = TRUE)  &&
+      requireNamespace("ggnetwork", quietly = TRUE))) {
   message("Packages 'ggplot2', 'viridis', 'igraph' and 'ggnetwork'  are needed for plotting this figure.")
 } else {
   library(ggplot2)
@@ -288,7 +291,8 @@ n_contact_fct = function(t){abs(round(rnorm(1, 0.5, 1), 0))}
 The distribution of `nContact` looks as follows:
 
 ```{r nContact2, echo=FALSE, message=FALSE}
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("dplyr", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) &&
+      requireNamespace("dplyr", quietly = TRUE))) {
   message("Packages 'ggplot2' and 'dplyr' are needed for plotting this figure.")
 } else {
   library(ggplot2)
@@ -331,7 +335,8 @@ Note that here `t_incub` and `p_max` are functions of `x` and not `t` (they are 
 Taken together, the profile for `pTrans` for a subset of 200 individuals in the population will look as follows:
 
 ```{r pTrans3, echo=FALSE}
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("dplyr", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) &&
+      requireNamespace("dplyr", quietly = TRUE))) {
   message("Packages 'ggplot2' and 'dplyr' are needed for plotting this figure.")
 } else {
   library(ggplot2)
@@ -488,7 +493,8 @@ n_contact_fct.B = function(t){sample(c(0,1,2),1,prob=c(0.6,0.3,0.1))}
 The distribution of `nContact.B` looks as follows:
 
 ```{r nContact2.B, echo=FALSE}
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("dplyr", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) && 
+      requireNamespace("dplyr", quietly = TRUE))) {
   message("Packages 'ggplot2' and 'dplyr' are needed for plotting this figure.")
 } else {
   library(ggplot2)
@@ -528,7 +534,8 @@ Note again that here `max.time` is a function of `x` and not `t` (not a core fun
 Taken together, the profile for `pTrans` for a subset of 200 individuals in the population will look as follow:
 
 ```{r pTrans3.B, echo=FALSE}
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("dplyr", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) && 
+      requireNamespace("dplyr", quietly = TRUE))) {
   message("Packages 'ggplot2' and 'dplyr' are needed for plotting this figure.")
 } else {
   library(ggplot2)

--- a/vignettes/discrete.Rmd
+++ b/vignettes/discrete.Rmd
@@ -57,7 +57,11 @@ if (!(requireNamespace("ggplot2", quietly = TRUE) &&
   library(igraph)
   library(ggnetwork)
   
-  transition.matrix <- matrix(c(0,0.2,0.4,0.5,0,0.6,0.5,0.8,0), nrow = 3, ncol = 3, dimnames=list(c("A","B","C"),c("A","B","C")))
+  transition.matrix <- matrix(c(0, 0.2, 0.4, 0.5, 0, 0.6, 0.5, 0.8, 0),
+                              nrow = 3,
+                              ncol = 3,
+                              dimnames=list(c("A", "B", "C"),
+                                            c("A", "B", "C")))
   
   # melting the matrix go get from -> to in one line with probability
   # melted.transition.matrix <- reshape2::melt(transition.matrix, varnames = c("from","to"), value.name="prob", as.is = TRUE)
@@ -65,23 +69,43 @@ if (!(requireNamespace("ggplot2", quietly = TRUE) &&
                                                   stringsAsFactors = FALSE)
   colnames(melted.transition.matrix) <- c("from", "to", "prob")
   
-  melted.transition.matrix <- subset(melted.transition.matrix, prob!=0)
+  melted.transition.matrix <- subset(melted.transition.matrix,
+                                     melted.transition.matrix$prob != 0)
   
-  graph.Matrix <- igraph::graph.data.frame(melted.transition.matrix,directed=T)
+  graph.Matrix <- igraph::graph.data.frame(melted.transition.matrix,
+                                           directed = TRUE)
   
-graph.Matrix <- igraph::graph.data.frame(melted.transition.matrix,directed=T)
   graph.Matrix2 = igraph::layout_in_circle(graph.Matrix)
   
-  graph.matrix.network <- ggnetwork::ggnetwork(graph.Matrix, layout = graph.Matrix2, arrow.gap=0.18) #using ggnetwork to provide the layout
+  #using ggnetwork to provide the layout
+  graph.matrix.network <- ggnetwork::ggnetwork(graph.Matrix,
+                                               layout = graph.Matrix2,
+                                               arrow.gap = 0.18) 
   
-  graph.matrix.network2 <- subset(graph.matrix.network, ! is.na(prob))
+  graph.matrix.network2 <- subset(graph.matrix.network,
+                                  !is.na(graph.matrix.network$prob))
   
   #plotting the network
   ggplot(graph.matrix.network, aes(x = x, y = y, xend = xend, yend = yend)) +
-    geom_edges(color = "grey70", arrow = arrow(length = unit(1, "lines"), type = "closed"), curvature = 0.2) + geom_nodes(aes(color = name) , size = 30) +
-    geom_nodetext(aes(label = name), color="white", fontface = "bold",size=15) + scale_color_viridis(guide=FALSE, discrete=TRUE) +
-    theme_blank() + ylim(-0.5,1.2) + xlim(-0.5,1.2) +
-    geom_text(data=graph.matrix.network2,aes(x=(x+xend)/2,y=(y+yend)/2,label = prob,color=name), size = 6)
+    geom_edges(color = "grey70",
+               arrow = arrow(length = unit(1, "lines"),
+                             type = "closed"),
+               curvature = 0.2) +
+    geom_nodes(aes(color = name) , size = 30) +
+    geom_nodetext(aes(label = name),
+                  color = "white",
+                  fontface = "bold",
+                  size = 15) +
+    scale_color_viridis(guide = FALSE, discrete = TRUE) +
+    theme_blank() +
+    ylim(-0.5, 1.2) +
+    xlim(-0.5, 1.2) +
+    geom_text(data = graph.matrix.network2,
+              aes(x = (x + xend) / 2,
+                  y = (y + yend) / 2,
+                  label = prob, 
+                  color = name),
+              size = 6)
 }
 ```
 

--- a/vignettes/discrete.Rmd
+++ b/vignettes/discrete.Rmd
@@ -4,20 +4,20 @@ author: "Sebastian Lequime"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-%\VignetteIndexEntry{Spread of a pathogen in a discrete structured population}
+  %\VignetteIndexEntry{Spread of a pathogen in a discrete structured population}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-  %\VignetteDepends{dplyr}
   %\VignetteDepends{ggplot2}
+  %\VignetteDepends{dplyr}
   %\VignetteDepends{igraph}
   %\VignetteDepends{viridis}
   %\VignetteDepends{ggnetwork}
-  ---
-  
-  ```{r setup, include=FALSE}
+---
+
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(
-collapse = TRUE,
-comment = "#>"
+  collapse = TRUE,
+  comment = "#>"
 )
 ```
 

--- a/vignettes/discrete.Rmd
+++ b/vignettes/discrete.Rmd
@@ -45,7 +45,7 @@ matrix(c(0, 0.2, 0.4,
 
 It can graphically be represented as follow:
 
-```{r setupMatrix, echo=FALSE, message=FALSE,warning=FALSE}
+```{r setupMatrix, echo=FALSE, message=FALSE, warning=FALSE}
 if (!(requireNamespace("ggplot2", quietly = TRUE) &&
       requireNamespace("viridis", quietly = TRUE) &&
       requireNamespace("igraph", quietly = TRUE)  &&

--- a/vignettes/nosoi.Rmd
+++ b/vignettes/nosoi.Rmd
@@ -73,13 +73,28 @@ if (!(requireNamespace("ggplot2", quietly = TRUE) &&
   graph.Matrix <- igraph::graph.data.frame(melted.transition.matrix,directed=T)
   graph.Matrix2 = igraph::layout_in_circle(graph.Matrix)
   
-  graph.simA.network <- ggnetwork::ggnetwork(graph.Matrix, layout = graph.Matrix2, arrow.gap=0.18) #using ggnetwork to provide the layout
+  if (utils::packageVersion("ggnetwork") > "0.5.12") {
+    # unfortunately, the update to igraph 2.0.0 has broken the connection
+    # between ggnetwork and igraph, see: 
+    # https://github.com/briatte/ggnetwork/issues/74
+    
+    #using ggnetwork to provide the layout
+    graph.simA.network <- ggnetwork::ggnetwork(graph.Matrix, layout = graph.Matrix2, arrow.gap=0.18) #using ggnetwork to provide the layout
   
   #plotting the network
   ggplot(graph.simA.network, aes(x = x, y = y, xend = xend, yend = yend)) +
     geom_edges(color = "grey70",arrow = arrow(length = unit(1, "lines"), type = "closed"),curvature = 0.2) + geom_nodes(aes(color = name) , size = 30) +
     geom_nodetext(aes(label = name),color="white", fontface = "bold",size=3) + scale_color_viridis(guide=FALSE,discrete=TRUE) +
     theme_blank() + ylim(-0.5,1.2) + xlim(-0.5,1.2)
+  } else {
+    plot(graph.Matrix,
+         vertex.shape = "none",
+         label.dist = 1,
+         layout = graph.Matrix2,
+         vertex.color = "white",
+         edge.curved = rep(-0.5, length = ecount(graph.Matrix)), 
+         edge.arrow.size = 0.5)
+  }
 }
 ```
 

--- a/vignettes/nosoi.Rmd
+++ b/vignettes/nosoi.Rmd
@@ -43,7 +43,10 @@ Each of these probabilities and numbers are computed during the simulation. In a
 Time is discretized in `nosoi`. Each time step follows the same pattern for each host:
 
 ```{r setupMatrix, echo=FALSE, message=FALSE,warning=FALSE}
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("viridis", quietly = TRUE) || !requireNamespace("igraph", quietly = TRUE) || !requireNamespace("ggnetwork", quietly = TRUE)) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) &&
+      requireNamespace("viridis", quietly = TRUE) &&
+      requireNamespace("igraph", quietly = TRUE)  &&
+      requireNamespace("ggnetwork", quietly = TRUE))) {
   message("Packages 'ggplot2', 'viridis', 'igraph' and 'ggnetwork'  are needed for plotting this figure.")
 } else {
   library(ggplot2)

--- a/vignettes/nosoi.Rmd
+++ b/vignettes/nosoi.Rmd
@@ -4,7 +4,7 @@ author: "Sebastian Lequime"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Getting-started}
+  %\VignetteIndexEntry{Getting started}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
   %\VignetteDepends{ggplot2}

--- a/vignettes/output.Rmd
+++ b/vignettes/output.Rmd
@@ -488,8 +488,8 @@ ggtree(test.nosoiA.tree.sampled, color = "gray30") + geom_nodepoint(aes(color=st
 }
 ```
 ```{r treeB_actual, echo=FALSE, message=FALSE}
-if (!requireNamespace("ggtree", quietly = TRUE) ||
-    (utils::packageVersion("ggtree") < "3.1.3")) {
+if (!(requireNamespace("ggtree", quietly = TRUE) &&
+    (utils::packageVersion("ggtree") < "3.1.3"))) {
   message("Package 'ggtree' is needed for plotting this figure.")
 } else {
   ggtree(test.nosoiA.tree.sampled, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + geom_tiplab(aes(label=host)) + 

--- a/vignettes/output.Rmd
+++ b/vignettes/output.Rmd
@@ -382,15 +382,19 @@ The following transmission tree can thus be extracted
 ```{r treeA, eval=FALSE, message=FALSE}
 test.nosoiA.tree <- getTransmissionTree(test.nosoiA)
 
-library(ggplot2)
-library(ggtree)
-if (requireNamespace("ggtree")) {
-ggtree(test.nosoiA.tree, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + 
-  theme_tree2() + xlab("Time (t)") + theme(legend.position = c(0,0.8), 
-                                           legend.title = element_blank(),
-                                           legend.key = element_blank())
+if (requireNamespace("ggtree", quietly = TRUE) &&
+    requireNamespace("ggplot2", quietly = TRUE)) {
+  library(ggtree)
+  library(ggplot2)
+ggtree(test.nosoiA.tree, color = "gray30") + 
+  geom_nodepoint(aes(color=state)) + 
+  geom_tippoint(aes(color=state)) + 
+  theme_tree2() + xlab("Time (t)") + 
+  theme(legend.position = c(0,0.8), 
+        legend.title = element_blank(),
+        legend.key = element_blank())
 } else {
-  message("Package 'ggtree' is needed for plotting")
+  message("Packages 'ggtree' and 'ggplot2' are needed for plotting")
 }
 ```
 ```{r treeA_actual, echo=FALSE, message=FALSE}
@@ -484,7 +488,8 @@ ggtree(test.nosoiA.tree.sampled, color = "gray30") + geom_nodepoint(aes(color=st
 }
 ```
 ```{r treeB_actual, echo=FALSE, message=FALSE}
-if (!requireNamespace("ggtree", quietly = TRUE) || (utils::packageVersion("ggtree") < "3.1.3")) {
+if (!requireNamespace("ggtree", quietly = TRUE) ||
+    (utils::packageVersion("ggtree") < "3.1.3")) {
   message("Package 'ggtree' is needed for plotting this figure.")
 } else {
   ggtree(test.nosoiA.tree.sampled, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + geom_tiplab(aes(label=host)) + 
@@ -532,8 +537,7 @@ if (!(requireNamespace("ape", quietly = TRUE) &&
 As before, the tree obtained is a `treedata` object, and can be plotted:
 
 ```{r treeC, eval=FALSE, message=FALSE}
-if (requireNamespace("ggtree", quietly = 
-                     TRUE)) {
+if (requireNamespace("ggtree", quietly = TRUE)) {
 ggtree(test.nosoiA.tree.sampled.exiting, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + geom_tiplab(aes(label=host)) + 
   theme_tree2() + xlab("Time (t)") + theme(legend.position = c(0,0.8), 
                                            legend.title = element_blank(),

--- a/vignettes/output.Rmd
+++ b/vignettes/output.Rmd
@@ -384,10 +384,14 @@ test.nosoiA.tree <- getTransmissionTree(test.nosoiA)
 
 library(ggplot2)
 library(ggtree)
+if (requireNamespace("ggtree")) {
 ggtree(test.nosoiA.tree, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + 
   theme_tree2() + xlab("Time (t)") + theme(legend.position = c(0,0.8), 
                                            legend.title = element_blank(),
-                                           legend.key = element_blank()) 
+                                           legend.key = element_blank())
+} else {
+  message("Package 'ggtree' is needed for plotting")
+}
 ```
 ```{r treeA_actual, echo=FALSE, message=FALSE}
 if (!(requireNamespace("ape", quietly = TRUE) &&
@@ -472,10 +476,12 @@ if (!(requireNamespace("ape", quietly = TRUE) &&
 As before, the tree obtained is a `treedata` object, and can be plotted:
 
 ```{r treeB, eval = FALSE, message=FALSE}
+if (!requireNamespace("ggtree", quietly = TRUE)) {
 ggtree(test.nosoiA.tree.sampled, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + geom_tiplab(aes(label=host)) + 
   theme_tree2() + xlab("Time (t)") + theme(legend.position = c(0,0.8), 
                                            legend.title = element_blank(),
                                            legend.key = element_blank()) 
+}
 ```
 ```{r treeB_actual, echo=FALSE, message=FALSE}
 if (!requireNamespace("ggtree", quietly = TRUE) || (utils::packageVersion("ggtree") < "3.1.3")) {
@@ -526,10 +532,15 @@ if (!(requireNamespace("ape", quietly = TRUE) &&
 As before, the tree obtained is a `treedata` object, and can be plotted:
 
 ```{r treeC, eval=FALSE, message=FALSE}
+if (requireNamespace("ggtree", quietly = 
+                     TRUE)) {
 ggtree(test.nosoiA.tree.sampled.exiting, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + geom_tiplab(aes(label=host)) + 
   theme_tree2() + xlab("Time (t)") + theme(legend.position = c(0,0.8), 
                                            legend.title = element_blank(),
                                            legend.key = element_blank()) 
+} else {
+  message("Package 'ggtree' required for plotting")
+}
 ```
 ```{r treeC_actual, echo=FALSE, message=FALSE}
 if (!(requireNamespace("ape", quietly = TRUE) && 

--- a/vignettes/output.Rmd
+++ b/vignettes/output.Rmd
@@ -390,13 +390,17 @@ ggtree(test.nosoiA.tree, color = "gray30") + geom_nodepoint(aes(color=state)) + 
                                            legend.key = element_blank()) 
 ```
 ```{r treeA_actual, echo=FALSE, message=FALSE}
-if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", quietly = TRUE) || !requireNamespace("treeio", quietly = TRUE)) {
-  message("Packages 'ape', 'tidytree' and 'treeio' are needed for transmission tree generation.")
+if (!(requireNamespace("ape", quietly = TRUE) &&
+      requireNamespace("tidytree", quietly = TRUE) &&
+      requireNamespace("treeio", quietly = TRUE))) {
+   message("Packages 'ape', 'tidytree' and 'treeio' are needed for transmission tree generation.")
 } else {
-  test.nosoiA.tree <- getTransmissionTree(test.nosoiA)
+   test.nosoiA.tree <- getTransmissionTree(test.nosoiA)
 }
 
-if (!requireNamespace("ggplot2", quietly = TRUE) || !requireNamespace("ggtree", quietly = TRUE) || (utils::packageVersion("ggtree") < "3.1.3")) {
+if (!(requireNamespace("ggplot2", quietly = TRUE) &&
+      requireNamespace("ggtree", quietly = TRUE) &&
+      (utils::packageVersion("ggtree") < "3.1.3"))) {
   message("Packages 'ggplot2' and 'ggtree (> 3.1.3)' are needed for plotting this figure.")
 } else {
   library(ggplot2)
@@ -431,7 +435,9 @@ Usually, it is unlikely that the whole transmission chain (i.e. every host) will
 In the example above, we want to sample the following 20 hosts:
 
 ```{r tree-sample1, echo=FALSE, message=FALSE}
-if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", quietly = TRUE) || !requireNamespace("treeio", quietly = TRUE)) {
+if (!(requireNamespace("ape", quietly = TRUE) &&       
+      requireNamespace("tidytree", quietly = TRUE) && 
+      requireNamespace("treeio", quietly = TRUE))) {
   message("Packages 'ape', 'tidytree' and 'treeio' are needed for transmission tree generation.")
 } else {
   library(dplyr)
@@ -454,7 +460,9 @@ if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", qu
 test.nosoiA.tree.sampled <- sampleTransmissionTree(test.nosoiA, test.nosoiA.tree, samples.data.table)
 ```
 ```{r tree-sample2_actual, echo=FALSE, message=FALSE}
-if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", quietly = TRUE) || !requireNamespace("treeio", quietly = TRUE)) {
+if (!(requireNamespace("ape", quietly = TRUE) && 
+      requireNamespace("tidytree", quietly = TRUE) && 
+      requireNamespace("treeio", quietly = TRUE))) {
   message("Packages 'ape', 'tidytree' and 'treeio' are needed for transmission tree generation.")
 } else {
   test.nosoiA.tree.sampled <- sampleTransmissionTree(test.nosoiA, test.nosoiA.tree, samples.data.table)
@@ -490,7 +498,9 @@ Alternatively, you can sample among exited hosts (i.e. no longer active at the e
 In our example, we want to sample these samples:
 
 ```{r tree-sample3, echo=FALSE, message=FALSE}
-if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", quietly = TRUE) || !requireNamespace("treeio", quietly = TRUE)) {
+if (!(requireNamespace("ape", quietly = TRUE) && 
+      requireNamespace("tidytree", quietly = TRUE) && 
+      requireNamespace("treeio", quietly = TRUE))) {
   message("Packages 'ape', 'tidytree' and 'treeio' are needed for transmission tree generation.")
 } else {
   set.seed(5905950)
@@ -504,7 +514,9 @@ if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", qu
 test.nosoiA.tree.sampled.exiting <- sampleTransmissionTreeFromExiting(test.nosoiA.tree, sampled.hosts)
 ```
 ```{r tree-sample4_actual, echo=FALSE, message=FALSE}
-if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", quietly = TRUE) || !requireNamespace("treeio", quietly = TRUE)) {
+if (!(requireNamespace("ape", quietly = TRUE) && 
+      requireNamespace("tidytree", quietly = TRUE) &&
+      requireNamespace("treeio", quietly = TRUE))) {
   message("Packages 'ape', 'tidytree' and 'treeio' are needed for transmission tree generation.")
 } else {
   test.nosoiA.tree.sampled.exiting <- sampleTransmissionTreeFromExiting(test.nosoiA.tree, sampled.hosts)
@@ -520,7 +532,11 @@ ggtree(test.nosoiA.tree.sampled.exiting, color = "gray30") + geom_nodepoint(aes(
                                            legend.key = element_blank()) 
 ```
 ```{r treeC_actual, echo=FALSE, message=FALSE}
-if (!requireNamespace("ape", quietly = TRUE) || !requireNamespace("tidytree", quietly = TRUE) || !requireNamespace("treeio", quietly = TRUE) || !requireNamespace("ggtree", quietly = TRUE) || (utils::packageVersion("ggtree") < "3.1.3")) {
+if (!(requireNamespace("ape", quietly = TRUE) && 
+      requireNamespace("tidytree", quietly = TRUE) && 
+      requireNamespace("treeio", quietly = TRUE) &&
+      requireNamespace("ggtree", quietly = TRUE) && 
+      (utils::packageVersion("ggtree") < "3.1.3"))) {
   message("Packages 'ape', 'tidytree', 'treeio' and 'ggtree' are needed for transmission tree generation.")
 } else {
   ggtree(test.nosoiA.tree.sampled.exiting, color = "gray30") + geom_nodepoint(aes(color=state)) + geom_tippoint(aes(color=state)) + geom_tiplab(aes(label=host)) + 

--- a/vignettes/output.Rmd
+++ b/vignettes/output.Rmd
@@ -4,7 +4,7 @@ author: "Sebastian Lequime"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{output-summarization}
+  %\VignetteIndexEntry{Output and summarization}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
   %\VignetteDepends{ape}


### PR DESCRIPTION
This PR fixes the following issues:
* checkRd: (-1) parseFunction.Rd:38: Lost braces in \itemize; \value handles \item{}{} directly
* Documented arguments not in \usage in Rd file 'FunctionSanityChecks.Rd':
* Documented arguments not in \usage in Rd file 'newLine.Rd':
* Documented arguments not in \usage in Rd file 'nosoiSimConstructor.Rd':
* Packages suggested but not available for checking: 'treeio', 'ggtree'
* Package unavailable to check Rd xrefs: ‘treeio’
* Error: processing vignette 'discrete.Rmd' failed with diagnostics:
  layout matrix dimensions do not match network size

Please note that that last issue is caused by igraph 2.0.0 breaking compatibility with ggnetwork (see here: https://github.com/briatte/ggnetwork/issues/74). For now, I have made a workaround by using the native igraph plotting, which looks much less nice - once ggnetwork gets updated, ggnetwork's plotting will be favoured again.